### PR TITLE
Centralize environment file loader

### DIFF
--- a/email_jobup_reader.py
+++ b/email_jobup_reader.py
@@ -15,19 +15,7 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-# ----------------------
-# .env loader (sans dépendance)
-# ----------------------
-def load_env_file(path: str = ".env") -> None:
-    if not os.path.isfile(path):
-        return
-    with open(path, "r", encoding="utf-8") as f:
-        for raw in f:
-            line = raw.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            k, v = line.split("=", 1)
-            os.environ.setdefault(k.strip(), v.strip())
+from utils import load_env_file
 
 load_env_file()
 

--- a/fullenrich_scraper.py
+++ b/fullenrich_scraper.py
@@ -5,20 +5,7 @@ import os
 import sys
 from math import ceil
 
-from utils import getenv_or_file
-
-# --- Chargement .env (sans dépendance externe) ---
-def load_env_file(path: str = ".env"):
-    if not os.path.isfile(path):
-        return
-    with open(path, "r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" in line:
-                k, v = line.split("=", 1)
-                os.environ.setdefault(k.strip(), v.strip())
+from utils import getenv_or_file, load_env_file
 
 load_env_file()  # charge FULLENRICH_API_KEY si présent
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,38 @@
+import os
+from typing import Optional
+
+
+def load_env_file(path: str = ".env") -> None:
+    """Load environment variables from a simple ``.env`` file.
+
+    Each non-empty, non-comment line should be of the form ``KEY=VALUE``.
+    Existing environment variables are not overridden.
+    """
+    if not os.path.isfile(path):
+        return
+    with open(path, "r", encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip())
+
+
+def getenv_or_file(key: str, filepath: str) -> Optional[str]:
+    """Return value from environment or from a local file.
+
+    Parameters
+    ----------
+    key: The environment variable name.
+    filepath: Fallback file whose first line provides the value if the
+        environment variable is missing.
+    """
+    val = os.getenv(key)
+    if val:
+        return val
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            return f.readline().strip() or None
+    except OSError:
+        return None


### PR DESCRIPTION
## Summary
- add reusable `load_env_file` to `utils`
- use shared loader in email_jobup_reader
- use shared loader in fullenrich_scraper

## Testing
- `python -m py_compile utils.py email_jobup_reader.py fullenrich_scraper.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6bcc992f0832c92bc58f59477c6e3