### PR TITLE
Improve DuckDuckGo LinkedIn link extraction

### DIFF
--- a/linkedin_company_retriever.py
+++ b/linkedin_company_retriever.py
@@ -7,7 +7,11 @@ from selenium.webdriver.support import expected_conditions as EC
 import pandas as pd
 import sys
 
-from utils import find_chromedriver_binary, normalize_linkedin_url, polite_delay
+from utils import (
+    find_chromedriver_binary,
+    find_first_linkedin_url,
+    polite_delay,
+)
 
 INPUT_XLSX = "offres_jobup.xlsx"
 OUTPUT_XLSX = "offres_jobup_company_linkedin.xlsx"
@@ -28,13 +32,13 @@ def search_company_on_duckduckgo(company_name: str) -> str | None:
     driver = webdriver.Chrome(service=service, options=options)
     try:
         driver.get(search_url)
-        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, "a")))
-        links = driver.find_elements(By.CSS_SELECTOR, "a[href*='linkedin.com/company']")
-        for a in links:
-            href = a.get_attribute("href") or ""
-            if "linkedin.com/company" in href:
-                return normalize_linkedin_url(href)
-        return None
+        selector = "[data-testid='result-title-a'], a[href*='duckduckgo.com/l/?uddg=']"
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, selector))
+        )
+        links = driver.find_elements(By.CSS_SELECTOR, selector)
+        hrefs = [(a.get_attribute("href") or "") for a in links]
+        return find_first_linkedin_url(hrefs, "linkedin.com/company")
     finally:
         driver.quit()
 

--- a/linkedin_profile_retriever.py
+++ b/linkedin_profile_retriever.py
@@ -7,7 +7,12 @@ from selenium.webdriver.support import expected_conditions as EC
 import pandas as pd
 import sys
 
-from utils import find_chromedriver_binary, normalize_linkedin_url, polite_delay
+from utils import (
+    find_chromedriver_binary,
+    find_first_linkedin_url,
+    normalize_linkedin_url,
+    polite_delay,
+)
 
 INPUT_XLSX = "offres_jobup_company_linkedin.xlsx"
 OUTPUT_XLSX = "offres_jobup_profile_linkedin.xlsx"
@@ -29,13 +34,13 @@ def find_ceo_profile(company_name: str) -> str | None:
     driver = webdriver.Chrome(service=service, options=options)
     try:
         driver.get(search_url)
-        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, "a")))
-        links = driver.find_elements(By.CSS_SELECTOR, "a[href*='linkedin.com/in']")
-        for a in links:
-            href = a.get_attribute("href") or ""
-            if "linkedin.com/in" in href:
-                return normalize_linkedin_url(href)
-        return None
+        selector = "[data-testid='result-title-a'], a[href*='duckduckgo.com/l/?uddg=']"
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, selector))
+        )
+        links = driver.find_elements(By.CSS_SELECTOR, selector)
+        hrefs = [(a.get_attribute("href") or "") for a in links]
+        return find_first_linkedin_url(hrefs, "linkedin.com/in")
     finally:
         driver.quit()
 

--- a/tests/test_duckduckgo_linkedin.py
+++ b/tests/test_duckduckgo_linkedin.py
@@ -1,0 +1,32 @@
+import unittest
+
+from utils import find_first_linkedin_url
+
+
+class DuckDuckGoLinkedInTests(unittest.TestCase):
+    def test_company_url_from_redirect(self) -> None:
+        hrefs = [
+            "https://example.com/irrelevant",
+            "https://duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.linkedin.com%2Fcompany%2Facme-labs%2F%3Ftrk%3Dpublic_profile",
+        ]
+        result = find_first_linkedin_url(hrefs, "linkedin.com/company")
+        self.assertEqual(result, "https://www.linkedin.com/company/acme-labs/")
+
+    def test_profile_url_from_direct_result(self) -> None:
+        hrefs = [
+            "https://duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.linkedin.com%2Ffeed/",
+            "https://linkedin.com/in/jane-doe-42a19b?utm_source=duckduckgo",
+        ]
+        result = find_first_linkedin_url(hrefs, "linkedin.com/in")
+        self.assertEqual(result, "https://www.linkedin.com/in/jane-doe-42a19b")
+
+    def test_no_match_returns_none(self) -> None:
+        hrefs = [
+            "https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com",
+            "https://example.org",
+        ]
+        self.assertIsNone(find_first_linkedin_url(hrefs, "linkedin.com/company"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- decode DuckDuckGo result URLs and extract normalized LinkedIn company links
- reuse the decoded result logic for profile searches via a shared helper
- cover the DuckDuckGo decoding flow with unit tests simulating search results

## Testing
- python -m unittest tests.test_duckduckgo_linkedin

------
https://chatgpt.com/codex/tasks/task_e_68cc43a34b24832ca3373317fa401037